### PR TITLE
support ReadonlySpan<byte> argument for LoadDictionary method

### DIFF
--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -42,6 +42,12 @@ namespace ZstdSharp
 
         public void LoadDictionary(byte[] dict)
         {
+            var dictReadOnlySpan = new ReadOnlySpan<byte>(dict);
+            this.LoadDictionary(dictReadOnlySpan);
+        }
+
+        public void LoadDictionary(ReadOnlySpan<byte> dict)
+        {
             EnsureNotDisposed();
             if (dict == null)
             {

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -35,6 +35,12 @@ namespace ZstdSharp
 
         public void LoadDictionary(byte[] dict)
         {
+            var dictReadOnlySpan = new ReadOnlySpan<byte>(dict);
+            this.LoadDictionary(dictReadOnlySpan);
+        }
+
+        public void LoadDictionary(ReadOnlySpan<byte> dict)
+        {
             EnsureNotDisposed();
             if (dict == null)
             {


### PR DESCRIPTION
I would like you have support to load dictionary from ReadOnlySpan<byte>.  This will help to load dictionary from preloaded memory stream without allocation a new byte array and coping from the existing memory. 