### PR TITLE
Return available data from stream, before waiting for more

### DIFF
--- a/src/ZstdSharp/DecompressionStream.cs
+++ b/src/ZstdSharp/DecompressionStream.cs
@@ -43,7 +43,7 @@ namespace ZstdSharp
             this.leaveOpen = leaveOpen;
             this.checkEndOfStream = checkEndOfStream;
 
-            inputBufferSize = bufferSize > 0 ? bufferSize : (int) Methods.ZSTD_CStreamInSize().EnsureZstdSuccess();
+            inputBufferSize = bufferSize > 0 ? bufferSize : (int) Methods.ZSTD_DStreamInSize().EnsureZstdSuccess();
             inputBuffer = ArrayPool<byte>.Shared.Rent(inputBufferSize);
             input = new ZSTD_inBuffer_s {pos = (nuint) inputBufferSize, size = (nuint) inputBufferSize};
         }


### PR DESCRIPTION
Previously, Read and ReadAsync would only return once the output buffer had been filled, or the inner stream returned 0 (i.e. when the inner stream ended). That meant it would not return already decoded data until it got more data from the inner stream, even if no more data was currently available. Now, instead:

- If the previous call filled the output buffer (which means there could potentially still be data buffered in the decompression context), try flushing that out by running DecompressStream, before trying to read more input.
- As soon as we have some output available, return it, so that we won't stall on reading from the inner stream before returning the decompressed data.

This does have the drawback that each call to Read will only call innerStream.Read at most once, so the amount of data the caller can get from a single Read call is limited by inputBufferSize.

Fixes #32