### PR TITLE
Cleanup code and improve reliability.

### DIFF
--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -49,15 +49,8 @@ namespace ZstdSharp
         public void LoadDictionary(ReadOnlySpan<byte> dict)
         {
             using var cctx = handle.Acquire();
-            if (dict == null)
-            {
-                Methods.ZSTD_CCtx_loadDictionary(cctx, null, 0).EnsureZstdSuccess();
-            }
-            else
-            {
-                fixed (byte* dictPtr = dict)
-                    Methods.ZSTD_CCtx_loadDictionary(cctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
-            }
+            fixed (byte* dictPtr = dict)
+                Methods.ZSTD_CCtx_loadDictionary(cctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
         }
 
         public Compressor(int level = DefaultCompressionLevel)

--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -11,13 +11,7 @@ namespace ZstdSharp
 
         private int level = DefaultCompressionLevel;
 
-        /*
-         * We have a finalizer that releases cctx (to prevent memory leaks if Disposed is not called),
-         * so we need to delay running the object's finalizer when dealing with cctx inside our methods.
-         * For this purpose we use GC.KeepAlive(this)
-         * For reference: https://devblogs.microsoft.com/oldnewthing/20100813-00/?p=13153
-         */
-        private ZSTD_CCtx_s* cctx;
+        private readonly SafeCctxHandle handle;
 
         public int Level
         {
@@ -34,17 +28,15 @@ namespace ZstdSharp
 
         public void SetParameter(ZSTD_cParameter parameter, int value)
         {
-            EnsureNotDisposed();
+            using var cctx = handle.Acquire();
             Methods.ZSTD_CCtx_setParameter(cctx, parameter, value).EnsureZstdSuccess();
-            GC.KeepAlive(this);
         }
 
         public int GetParameter(ZSTD_cParameter parameter)
         {
-            EnsureNotDisposed();
+            using var cctx = handle.Acquire();
             int value;
             Methods.ZSTD_CCtx_getParameter(cctx, parameter, &value).EnsureZstdSuccess();
-            GC.KeepAlive(this);
             return value;
         }
 
@@ -56,39 +48,29 @@ namespace ZstdSharp
 
         public void LoadDictionary(ReadOnlySpan<byte> dict)
         {
-            EnsureNotDisposed();
+            using var cctx = handle.Acquire();
             if (dict == null)
             {
                 Methods.ZSTD_CCtx_loadDictionary(cctx, null, 0).EnsureZstdSuccess();
             }
             else
             {
-
                 fixed (byte* dictPtr = dict)
-                    Methods.ZSTD_CCtx_loadDictionary(cctx, dictPtr, (nuint) dict.Length).EnsureZstdSuccess();
+                    Methods.ZSTD_CCtx_loadDictionary(cctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
             }
-            GC.KeepAlive(this);
         }
 
         public Compressor(int level = DefaultCompressionLevel)
         {
-            cctx = Methods.ZSTD_createCCtx();
-            if (cctx == null)
-                throw new ZstdException(ZSTD_ErrorCode.ZSTD_error_GENERIC, "Failed to create cctx");
-
+            handle = SafeCctxHandle.Create();
             Level = level;
         }
 
-        ~Compressor()
-        {
-            ReleaseUnmanagedResources();
-        }
-
-        public static int GetCompressBound(int length) 
-            => (int) Methods.ZSTD_compressBound((nuint) length);
+        public static int GetCompressBound(int length)
+            => (int)Methods.ZSTD_compressBound((nuint)length);
 
         public static ulong GetCompressBoundLong(ulong length)
-            => Methods.ZSTD_compressBound((nuint) length);
+            => Methods.ZSTD_compressBound((nuint)length);
 
         public Span<byte> Wrap(ReadOnlySpan<byte> src)
         {
@@ -102,22 +84,19 @@ namespace ZstdSharp
 
         public int Wrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            EnsureNotDisposed();
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
-                var returnValue = (int) Methods
-                    .ZSTD_compress2(cctx, destPtr, (nuint) dest.Length, srcPtr, (nuint) src.Length)
+                using var cctx = handle.Acquire();
+                return (int)Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
-                GC.KeepAlive(this);
-                return returnValue;
             }
         }
 
-        public int Wrap(ArraySegment<byte> src, ArraySegment<byte> dest) 
-            => Wrap((ReadOnlySpan<byte>) src, dest);
+        public int Wrap(ArraySegment<byte> src, ArraySegment<byte> dest)
+            => Wrap((ReadOnlySpan<byte>)src, dest);
 
-        public int Wrap(byte[] src, int srcOffset, int srcLength, byte[] dst, int dstOffset, int dstLength) 
+        public int Wrap(byte[] src, int srcOffset, int srcLength, byte[] dst, int dstOffset, int dstLength)
             => Wrap(new ReadOnlySpan<byte>(src, srcOffset, srcLength), new Span<byte>(dst, dstOffset, dstLength));
 
         public bool TryWrap(byte[] src, byte[] dest, int offset, out int written)
@@ -125,12 +104,16 @@ namespace ZstdSharp
 
         public bool TryWrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            EnsureNotDisposed();
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
-                var returnValue =
-                    Methods.ZSTD_compress2(cctx, destPtr, (nuint) dest.Length, srcPtr, (nuint) src.Length);
+                nuint returnValue;
+                using (var cctx = handle.Acquire())
+                {
+                    returnValue =
+                        Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
+                }
+
                 GC.KeepAlive(this);
 
                 if (returnValue == unchecked(0 - (nuint)ZSTD_ErrorCode.ZSTD_error_dstSize_tooSmall))
@@ -140,7 +123,7 @@ namespace ZstdSharp
                 }
 
                 returnValue.EnsureZstdSuccess();
-                written = (int) returnValue;
+                written = (int)returnValue;
                 return true;
             }
         }
@@ -151,25 +134,10 @@ namespace ZstdSharp
         public bool TryWrap(byte[] src, int srcOffset, int srcLength, byte[] dst, int dstOffset, int dstLength, out int written)
             => TryWrap(new ReadOnlySpan<byte>(src, srcOffset, srcLength), new Span<byte>(dst, dstOffset, dstLength), out written);
 
-        private void ReleaseUnmanagedResources()
-        {
-            if (cctx != null)
-            {
-                Methods.ZSTD_freeCCtx(cctx);
-                cctx = null;
-            }
-        }
-
         public void Dispose()
         {
-            ReleaseUnmanagedResources();
+            handle.Dispose();
             GC.SuppressFinalize(this);
-        }
-
-        private void EnsureNotDisposed()
-        {
-            if (cctx == null)
-                throw new ObjectDisposedException(nameof(Compressor));
         }
 
         internal nuint CompressStream(ref ZSTD_inBuffer_s input, ref ZSTD_outBuffer_s output, ZSTD_EndDirective directive)
@@ -177,9 +145,8 @@ namespace ZstdSharp
             fixed (ZSTD_inBuffer_s* inputPtr = &input)
             fixed (ZSTD_outBuffer_s* outputPtr = &output)
             {
-                var returnValue = Methods.ZSTD_compressStream2(cctx, outputPtr, inputPtr, directive).EnsureZstdSuccess();
-                GC.KeepAlive(this);
-                return returnValue;
+                using var cctx = handle.Acquire();
+                return Methods.ZSTD_compressStream2(cctx, outputPtr, inputPtr, directive).EnsureZstdSuccess();
             }
         }
     }

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -35,15 +35,8 @@ namespace ZstdSharp
         public void LoadDictionary(ReadOnlySpan<byte> dict)
         {
             using var dctx = handle.Acquire();
-            if (dict == null)
-            {
-                Methods.ZSTD_DCtx_loadDictionary(dctx, null, 0).EnsureZstdSuccess();
-            }
-            else
-            {
-                fixed (byte* dictPtr = dict)
-                    Methods.ZSTD_DCtx_loadDictionary(dctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
-            }
+            fixed (byte* dictPtr = dict)
+                Methods.ZSTD_DCtx_loadDictionary(dctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
         }
 
         public static ulong GetDecompressedSize(ReadOnlySpan<byte> src)

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -5,39 +5,24 @@ namespace ZstdSharp
 {
     public unsafe class Decompressor : IDisposable
     {
-        /*
-         * We have a finalizer that releases dctx (to prevent memory leaks if Disposed is not called),
-         * so we need to delay running the object's finalizer when dealing with dctx inside our methods.
-         * For this purpose we use GC.KeepAlive(this)
-         * For reference: https://devblogs.microsoft.com/oldnewthing/20100813-00/?p=13153
-         */
-        private ZSTD_DCtx_s* dctx;
+        private readonly SafeDctxHandle handle;
 
         public Decompressor()
         {
-            dctx = Methods.ZSTD_createDCtx();
-            if (dctx == null)
-                throw new ZstdException(ZSTD_ErrorCode.ZSTD_error_GENERIC, "Failed to create dctx");
-        }
-
-        ~Decompressor()
-        {
-            ReleaseUnmanagedResources();
+            handle = SafeDctxHandle.Create();
         }
 
         public void SetParameter(ZSTD_dParameter parameter, int value)
         {
-            EnsureNotDisposed();
+            using var dctx = handle.Acquire();
             Methods.ZSTD_DCtx_setParameter(dctx, parameter, value).EnsureZstdSuccess();
-            GC.KeepAlive(this);
         }
 
         public int GetParameter(ZSTD_dParameter parameter)
         {
-            EnsureNotDisposed();
+            using var dctx = handle.Acquire();
             int value;
             Methods.ZSTD_DCtx_getParameter(dctx, parameter, &value).EnsureZstdSuccess();
-            GC.KeepAlive(this);
             return value;
         }
 
@@ -49,7 +34,7 @@ namespace ZstdSharp
 
         public void LoadDictionary(ReadOnlySpan<byte> dict)
         {
-            EnsureNotDisposed();
+            using var dctx = handle.Acquire();
             if (dict == null)
             {
                 Methods.ZSTD_DCtx_loadDictionary(dctx, null, 0).EnsureZstdSuccess();
@@ -57,19 +42,18 @@ namespace ZstdSharp
             else
             {
                 fixed (byte* dictPtr = dict)
-                    Methods.ZSTD_DCtx_loadDictionary(dctx, dictPtr, (nuint) dict.Length).EnsureZstdSuccess();
+                    Methods.ZSTD_DCtx_loadDictionary(dctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
             }
-            GC.KeepAlive(this);
         }
 
         public static ulong GetDecompressedSize(ReadOnlySpan<byte> src)
         {
             fixed (byte* srcPtr = src)
-                return Methods.ZSTD_decompressBound(srcPtr, (nuint) src.Length).EnsureContentSizeOk();
+                return Methods.ZSTD_decompressBound(srcPtr, (nuint)src.Length).EnsureContentSizeOk();
         }
 
         public static ulong GetDecompressedSize(ArraySegment<byte> src)
-            => GetDecompressedSize((ReadOnlySpan<byte>) src);
+            => GetDecompressedSize((ReadOnlySpan<byte>)src);
 
         public static ulong GetDecompressedSize(byte[] src, int srcOffset, int srcLength)
             => GetDecompressedSize(new ReadOnlySpan<byte>(src, srcOffset, srcLength));
@@ -77,7 +61,7 @@ namespace ZstdSharp
         public Span<byte> Unwrap(ReadOnlySpan<byte> src, int maxDecompressedSize = int.MaxValue)
         {
             var expectedDstSize = GetDecompressedSize(src);
-            if (expectedDstSize > (ulong) maxDecompressedSize)
+            if (expectedDstSize > (ulong)maxDecompressedSize)
                 throw new ZstdException(ZSTD_ErrorCode.ZSTD_error_dstSize_tooSmall,
                     $"Decompressed content size {expectedDstSize} is greater than {nameof(maxDecompressedSize)} {maxDecompressedSize}");
             if (expectedDstSize > Constants.MaxByteArrayLength)
@@ -89,20 +73,18 @@ namespace ZstdSharp
             return new Span<byte>(dest, 0, length);
         }
 
-        public int Unwrap(byte[] src, byte[] dest, int offset) 
+        public int Unwrap(byte[] src, byte[] dest, int offset)
             => Unwrap(src, new Span<byte>(dest, offset, dest.Length - offset));
 
         public int Unwrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            EnsureNotDisposed();
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
-                var returnValue = (int) Methods
-                    .ZSTD_decompressDCtx(dctx, destPtr, (nuint) dest.Length, srcPtr, (nuint) src.Length)
+                using var dctx = handle.Acquire();
+                return (int)Methods
+                    .ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
-                GC.KeepAlive(this);
-                return returnValue;
             }
         }
 
@@ -114,12 +96,16 @@ namespace ZstdSharp
 
         public bool TryUnwrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            EnsureNotDisposed();
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
-                var returnValue =
-                    Methods.ZSTD_decompressDCtx(dctx, destPtr, (nuint) dest.Length, srcPtr, (nuint) src.Length);
+                nuint returnValue;
+                using (var dctx = handle.Acquire())
+                {
+                    returnValue =
+                        Methods.ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
+                }
+
                 GC.KeepAlive(this);
 
                 if (returnValue == unchecked(0 - (nuint)ZSTD_ErrorCode.ZSTD_error_dstSize_tooSmall))
@@ -129,7 +115,7 @@ namespace ZstdSharp
                 }
 
                 returnValue.EnsureZstdSuccess();
-                written = (int) returnValue;
+                written = (int)returnValue;
                 return true;
             }
         }
@@ -137,24 +123,10 @@ namespace ZstdSharp
         public bool TryUnwrap(byte[] src, int srcOffset, int srcLength, byte[] dst, int dstOffset, int dstLength, out int written)
             => TryUnwrap(new ReadOnlySpan<byte>(src, srcOffset, srcLength), new Span<byte>(dst, dstOffset, dstLength), out written);
 
-        private void ReleaseUnmanagedResources()
-        {
-            if (dctx != null)
-            {
-                Methods.ZSTD_freeDCtx(dctx);
-                dctx = null;
-            }
-        }
-
         public void Dispose()
         {
-            ReleaseUnmanagedResources();
+            handle.Dispose();
             GC.SuppressFinalize(this);
-        }
-        private void EnsureNotDisposed()
-        {
-            if (dctx == null)
-                throw new ObjectDisposedException(nameof(Decompressor));
         }
 
         internal nuint DecompressStream(ref ZSTD_inBuffer_s input, ref ZSTD_outBuffer_s output)
@@ -162,9 +134,8 @@ namespace ZstdSharp
             fixed (ZSTD_inBuffer_s* inputPtr = &input)
             fixed (ZSTD_outBuffer_s* outputPtr = &output)
             {
-                var returnValue = Methods.ZSTD_decompressStream(dctx, outputPtr, inputPtr).EnsureZstdSuccess();
-                GC.KeepAlive(this);
-                return returnValue;
+                using var dctx = handle.Acquire();
+                return Methods.ZSTD_decompressStream(dctx, outputPtr, inputPtr).EnsureZstdSuccess();
             }
         }
     }

--- a/src/ZstdSharp/FodyWeavers.xml
+++ b/src/ZstdSharp/FodyWeavers.xml
@@ -1,4 +1,3 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <InlineIL/>
   <InlineMethod />
 </Weavers>

--- a/src/ZstdSharp/FodyWeavers.xsd
+++ b/src/ZstdSharp/FodyWeavers.xsd
@@ -5,63 +5,6 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="InlineMethod" minOccurs="0" maxOccurs="1" type="xs:anyType" />
-        <xs:element name="InlineIL" minOccurs="0" maxOccurs="1">
-          <xs:complexType>
-            <xs:attribute name="SequencePoints">
-              <xs:annotation>
-                <xs:documentation>Defines if sequence points should be generated for each emitted IL instruction. Default value: Debug</xs:documentation>
-              </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Debug">
-                    <xs:annotation>
-                      <xs:documentation>Insert sequence points in Debug builds only (this is the default).</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="Release">
-                    <xs:annotation>
-                      <xs:documentation>Insert sequence points in Release builds only.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="True">
-                    <xs:annotation>
-                      <xs:documentation>Always insert sequence points.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="False">
-                    <xs:annotation>
-                      <xs:documentation>Never insert sequence points.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                </xs:restriction>
-              </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="Warnings">
-              <xs:annotation>
-                <xs:documentation>Defines how warnings should be handled. Default value: Warnings</xs:documentation>
-              </xs:annotation>
-              <xs:simpleType>
-                <xs:restriction base="xs:string">
-                  <xs:enumeration value="Warnings">
-                    <xs:annotation>
-                      <xs:documentation>Emit build warnings (this is the default).</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="Ignore">
-                    <xs:annotation>
-                      <xs:documentation>Do not emit warnings.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                  <xs:enumeration value="Errors">
-                    <xs:annotation>
-                      <xs:documentation>Treat warnings as errors.</xs:documentation>
-                    </xs:annotation>
-                  </xs:enumeration>
-                </xs:restriction>
-              </xs:simpleType>
-            </xs:attribute>
-          </xs:complexType>
-        </xs:element>
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">
         <xs:annotation>

--- a/src/ZstdSharp/SafeHandles.cs
+++ b/src/ZstdSharp/SafeHandles.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using ZstdSharp.Unsafe;
 
@@ -65,9 +65,12 @@ namespace ZstdSharp
         }
 
         /// <summary>
-        /// Acquires a reference to the 
+        /// Acquires a reference to the safe handle.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="SafeHandleHolder{T}"/> instance that can be implicitly converted to a pointer
+        /// to <see cref="ZSTD_CCtx_s"/>.
+        /// </returns>
         public SafeHandleHolder<ZSTD_CCtx_s> Acquire() => new(this);
 
         protected override bool ReleaseHandle()
@@ -113,6 +116,13 @@ namespace ZstdSharp
             return safeHandle;
         }
 
+        /// <summary>
+        /// Acquires a reference to the safe handle.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="SafeHandleHolder{T}"/> instance that can be implicitly converted to a pointer
+        /// to <see cref="ZSTD_DCtx_s"/>.
+        /// </returns>
         public SafeHandleHolder<ZSTD_DCtx_s> Acquire() => new(this);
 
         protected override bool ReleaseHandle()

--- a/src/ZstdSharp/SafeHandles.cs
+++ b/src/ZstdSharp/SafeHandles.cs
@@ -72,7 +72,7 @@ namespace ZstdSharp
 
         protected override bool ReleaseHandle()
         {
-            return Methods.ZSTD_freeCStream((ZSTD_CCtx_s*)handle) == 0;
+            return Methods.ZSTD_freeCCtx((ZSTD_CCtx_s*)handle) == 0;
         }
     }
 
@@ -117,7 +117,7 @@ namespace ZstdSharp
 
         protected override bool ReleaseHandle()
         {
-            return Methods.ZSTD_freeDStream((ZSTD_DCtx_s*)handle) == 0;
+            return Methods.ZSTD_freeDCtx((ZSTD_DCtx_s*)handle) == 0;
         }
     }
 

--- a/src/ZstdSharp/SafeHandles.cs
+++ b/src/ZstdSharp/SafeHandles.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ZstdSharp.Unsafe;
+
+namespace ZstdSharp
+{
+    /// <summary>
+    /// Provides the base class for ZstdSharp <see cref="SafeHandle"/> implementations.
+    /// </summary>
+    /// <remarks>
+    /// Even though ZstdSharp is a managed library, its internals are using unmanaged
+    /// memory and we are using safe handles in the library's high-level API to ensure
+    /// proper disposal of unmanaged resources and increase safety.
+    /// </remarks>
+    /// <seealso cref="SafeCctxHandle"/>
+    /// <seealso cref="SafeDctxHandle"/>
+    internal abstract unsafe class SafeZstdHandle : SafeHandle
+    {
+        /// <summary>
+        /// Parameterless constructor is hidden. Use the static <c>Create</c> factory
+        /// method to create a new safe handle instance.
+        /// </summary>
+        protected SafeZstdHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public sealed override bool IsInvalid => handle == IntPtr.Zero;
+    }
+
+    /// <summary>
+    /// Safely wraps an unmanaged Zstd compression context.
+    /// </summary>
+    internal sealed unsafe class SafeCctxHandle : SafeZstdHandle
+    {
+        /// <inheritdoc/>
+        private SafeCctxHandle()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SafeCctxHandle"/>.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ZstdException">Creation failed.</exception>
+        public static SafeCctxHandle Create()
+        {
+            var safeHandle = new SafeCctxHandle();
+            bool success = false;
+            try
+            {
+                var cctx = Methods.ZSTD_createCCtx();
+                if (cctx == null)
+                    throw new ZstdException(ZSTD_ErrorCode.ZSTD_error_GENERIC, "Failed to create cctx");
+                safeHandle.SetHandle((IntPtr)cctx);
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    safeHandle.SetHandleAsInvalid();
+                }
+            }
+            return safeHandle;
+        }
+
+        /// <summary>
+        /// Acquires a reference to the 
+        /// </summary>
+        /// <returns></returns>
+        public SafeHandleHolder<ZSTD_CCtx_s> Acquire() => new(this);
+
+        protected override bool ReleaseHandle()
+        {
+            return Methods.ZSTD_freeCStream((ZSTD_CCtx_s*)handle) == 0;
+        }
+    }
+
+    /// <summary>
+    /// Safely wraps an unmanaged Zstd compression context.
+    /// </summary>
+    internal sealed unsafe class SafeDctxHandle : SafeZstdHandle
+    {
+        /// <inheritdoc/>
+        private SafeDctxHandle()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SafeDctxHandle"/>.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ZstdException">Creation failed.</exception>
+        public static SafeDctxHandle Create()
+        {
+            var safeHandle = new SafeDctxHandle();
+            bool success = false;
+            try
+            {
+                var dctx = Methods.ZSTD_createDCtx();
+                if (dctx == null)
+                    throw new ZstdException(ZSTD_ErrorCode.ZSTD_error_GENERIC, "Failed to create dctx");
+                safeHandle.SetHandle((IntPtr)dctx);
+                success = true;
+            }
+            finally
+            {
+                if (!success)
+                {
+                    safeHandle.SetHandleAsInvalid();
+                }
+            }
+            return safeHandle;
+        }
+
+        public SafeHandleHolder<ZSTD_DCtx_s> Acquire() => new(this);
+
+        protected override bool ReleaseHandle()
+        {
+            return Methods.ZSTD_freeDStream((ZSTD_DCtx_s*)handle) == 0;
+        }
+    }
+
+    /// <summary>
+    /// Provides a convenient interface to safely acquire pointers of a specific type
+    /// from a <see cref="SafeHandle"/>, by utilizing <see langword="using"/> blocks.
+    /// </summary>
+    /// <typeparam name="T">The type of pointers to return.</typeparam>
+    /// <remarks>
+    /// Safe handle holders can be <see cref="Dispose"/>d to decrement the safe handle's
+    /// reference count, and can be implicitly converted to pointers to <see cref="T"/>.
+    /// </remarks>
+    internal unsafe ref struct SafeHandleHolder<T> where T : unmanaged
+    {
+        private readonly SafeHandle _handle;
+
+        private bool _refAdded;
+
+        public SafeHandleHolder(SafeHandle safeHandle)
+        {
+            _handle = safeHandle;
+            _refAdded = false;
+            safeHandle.DangerousAddRef(ref _refAdded);
+        }
+
+        public static implicit operator T*(SafeHandleHolder<T> holder) =>
+            (T*)holder._handle.DangerousGetHandle();
+
+        public void Dispose()
+        {
+            if (_refAdded)
+            {
+                _handle.DangerousRelease();
+                _refAdded = false;
+            }
+        }
+    }
+}

--- a/src/ZstdSharp/Unsafe/Mem.cs
+++ b/src/ZstdSharp/Unsafe/Mem.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
-using InlineIL;
-using static InlineIL.IL.Emit;
+using BclUnsafe = System.Runtime.CompilerServices.Unsafe;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo
@@ -20,13 +19,13 @@ namespace ZstdSharp.Unsafe
         /*=== Static platform detection ===*/
         public static bool MEM_32bits
         {
-            [InlineMethod.Inline]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => sizeof(nint) == 4;
         }
 
         public static bool MEM_64bits
         {
-            [InlineMethod.Inline]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => sizeof(nint) == 8;
         }
 
@@ -35,87 +34,62 @@ namespace ZstdSharp.Unsafe
            can sometimes prove slower */
         private static ushort MEM_read16(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_U2();
-            return IL.Return<ushort>();
+            return BclUnsafe.ReadUnaligned<ushort>(memPtr);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint MEM_read32(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_U4();
-            return IL.Return<uint>();
+            return BclUnsafe.ReadUnaligned<uint>(memPtr);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong MEM_read64(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_I8();
-            return IL.Return<ulong>();
+            return BclUnsafe.ReadUnaligned<ulong>(memPtr);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static nuint MEM_readST(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_I();
-            return IL.Return<nuint>();
+            return BclUnsafe.ReadUnaligned<nuint>(memPtr);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_write16(void* memPtr, ushort value)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(value));
-            Unaligned(1);
-            Stind_I2();
+            BclUnsafe.WriteUnaligned(memPtr, value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_write64(void* memPtr, ulong value)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(value));
-            Unaligned(1);
-            Stind_I8();
+            BclUnsafe.WriteUnaligned(memPtr, value);
         }
 
         /*=== Little endian r/w ===*/
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ushort MEM_readLE16(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_U2();
+            var num = BclUnsafe.ReadUnaligned<ushort>(memPtr);
 
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness), typeof(ushort)));
+                num = BinaryPrimitives.ReverseEndianness(num);
             }
 
-            return IL.Return<ushort>();
+            return num;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_writeLE16(void* memPtr, ushort val)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(val));
-
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness),
-                    typeof(ushort)));
+                val = BinaryPrimitives.ReverseEndianness(val);
             }
 
-            Unaligned(1);
-            Stind_I2();
+            BclUnsafe.WriteUnaligned(memPtr, val);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -132,99 +106,65 @@ namespace ZstdSharp.Unsafe
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint MEM_readLE32(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_U4();
+            var num = BclUnsafe.ReadUnaligned<uint>(memPtr);
 
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness), typeof(uint)));
+                num = BinaryPrimitives.ReverseEndianness(num);
             }
 
-            return IL.Return<uint>();
+            return num;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_writeLE32(void* memPtr, uint val32)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(val32));
-
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness),
-                    typeof(uint)));
+                val32 = BinaryPrimitives.ReverseEndianness(val32);
             }
 
-            Unaligned(1);
-            Stind_I4();
+            BclUnsafe.WriteUnaligned(memPtr, val32);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong MEM_readLE64(void* memPtr)
         {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_I8();
+            var num = BclUnsafe.ReadUnaligned<ulong>(memPtr);
 
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness), typeof(ulong)));
+                num = BinaryPrimitives.ReverseEndianness(num);
             }
 
-            return IL.Return<ulong>();
+            return num;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_writeLE64(void* memPtr, ulong val64)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(val64));
-
             if (!BitConverter.IsLittleEndian)
             {
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness),
-                    typeof(ulong)));
+                val64 = BinaryPrimitives.ReverseEndianness(val64);
             }
 
-            Unaligned(1);
-            Stind_I8();
+            BclUnsafe.WriteUnaligned(memPtr, val64);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static nuint MEM_readLEST(void* memPtr)
-        {
-            Ldarg(nameof(memPtr));
-            Unaligned(1);
-            Ldind_I();
-
-            if (!BitConverter.IsLittleEndian)
-            {
-                Conv_U8();
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness),
-                    typeof(ulong)));
-                Conv_U();
-            }
-
-            return IL.Return<nuint>();
-        }
+        private static nuint MEM_readLEST(void* memPtr) => MEM_32bits ? MEM_readLE32(memPtr) : (nuint)MEM_readLE64(memPtr);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void MEM_writeLEST(void* memPtr, nuint val)
         {
-            Ldarg(nameof(memPtr));
-            Ldarg(nameof(val));
-
-            if (!BitConverter.IsLittleEndian)
+            if (MEM_32bits)
             {
-                Conv_U8();
-                Call(new MethodRef(typeof(BinaryPrimitives), nameof(BinaryPrimitives.ReverseEndianness),
-                    typeof(ulong)));
-                Conv_U();
+                MEM_writeLE32(memPtr, (uint)val);
             }
-
-            Unaligned(1);
-            Stind_I();
+            else
+            {
+                MEM_writeLE64(memPtr, val);
+            }
         }
     }
 }

--- a/src/ZstdSharp/Unsafe/Mem.cs
+++ b/src/ZstdSharp/Unsafe/Mem.cs
@@ -19,13 +19,13 @@ namespace ZstdSharp.Unsafe
         /*=== Static platform detection ===*/
         public static bool MEM_32bits
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [InlineMethod.Inline]
             get => sizeof(nint) == 4;
         }
 
         public static bool MEM_64bits
         {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            [InlineMethod.Inline]
             get => sizeof(nint) == 8;
         }
 

--- a/src/ZstdSharp/UnsafeHelper.cs
+++ b/src/ZstdSharp/UnsafeHelper.cs
@@ -1,9 +1,7 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using InlineIL;
-
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo
 
@@ -15,7 +13,7 @@ namespace ZstdSharp
     {
         public static void* PoisonMemory(void* destination, ulong size)
         {
-            memset(destination, 0xCC, (uint) size);
+            memset(destination, 0xCC, (uint)size);
             return destination;
         }
 
@@ -57,8 +55,8 @@ namespace ZstdSharp
 #else
             var total = num * size;
             assert(total <= uint.MaxValue);
-            var destination = (void*) Marshal.AllocHGlobal((nint) total);
-            memset(destination, 0, (uint) total);
+            var destination = (void*)Marshal.AllocHGlobal((nint)total);
+            memset(destination, 0, (uint)total);
             return destination;
 #endif
         }
@@ -92,8 +90,8 @@ namespace ZstdSharp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T* GetArrayPointer<T>(T[] array) where T : unmanaged
         {
-            var size = (uint) (sizeof(T) * array.Length);
-            var destination = (T*) malloc(size);
+            var size = (uint)(sizeof(T) * array.Length);
+            var destination = (T*)malloc(size);
             fixed (void* source = &array[0])
                 System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(destination, source, size);
 
@@ -125,13 +123,7 @@ namespace ZstdSharp
         [InlineMethod.Inline]
         public static void SkipInit<T>(out T value)
         {
-            /* 
-             * Can be rewritten with
-             * System.Runtime.CompilerServices.Unsafe.SkipInit(out value);
-             * in .NET 5+
-             */
-            IL.Emit.Ret();
-            throw IL.Unreachable();
+            System.Runtime.CompilerServices.Unsafe.SkipInit(out value);
         }
     }
 }

--- a/src/ZstdSharp/UnsafeHelper.cs
+++ b/src/ZstdSharp/UnsafeHelper.cs
@@ -91,7 +91,15 @@ namespace ZstdSharp
         public static T* GetArrayPointer<T>(T[] array) where T : unmanaged
         {
             var size = (uint)(sizeof(T) * array.Length);
+#if NET5_0_OR_GREATER
+            // This function is used to allocate memory for static data blocks.
+            // We have to use AllocateTypeAssociatedMemory and link the memory's
+            // lifetime to this assembly, in order to prevent memory leaks when
+            // loading the assembly in an unloadable AssemblyLoadContext.
+            var destination = (T*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UnsafeHelper), (int)size);
+#else
             var destination = (T*)malloc(size);
+#endif
             fixed (void* source = &array[0])
                 System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(destination, source, size);
 

--- a/src/ZstdSharp/ZstdSharp.csproj
+++ b/src/ZstdSharp/ZstdSharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'!='net7.0'">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
@@ -44,7 +44,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="InlineIL.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="InlineMethod.Fody" Version="0.7.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ZstdSharp/ZstdSharp.csproj
+++ b/src/ZstdSharp/ZstdSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='net7.0'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR:

* Removes the dependency to the `InlineIL` package. All its uses can be replaced by the `System.Runtime.CompilerServices.Unsafe` package or other built-in .NET APIs, and the replaced code is simpler.
* Updates the high-level `Compressor` and `Decompressor` classes to use classes derived from `SafeHandle` to manage the ZSTD context pointers. While safe handles are usually used for interop with native code, we use them here in managed code to manage the lifetime of manually allocated memory. This makes the code simpler and much more reliable; you don't have to write `GC.KeepAlive`s anymore, and safe handles protect from cases like one thread calling `Dispose` while another thread uses the resource.
* Removes two cases where spans were compared to `null`. This is not valid code since spans are structs and not classes.