### PR TITLE
[De]CompressionStream - Only return non-null buffers to pool

### DIFF
--- a/src/ZstdSharp/CompressionStream.cs
+++ b/src/ZstdSharp/CompressionStream.cs
@@ -109,7 +109,10 @@ namespace ZstdSharp
             }
             compressor = null;
 
-            ArrayPool<byte>.Shared.Return(outputBuffer);
+            if (outputBuffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(outputBuffer);
+            }
 
             if (!leaveOpen)
             {

--- a/src/ZstdSharp/DecompressionStream.cs
+++ b/src/ZstdSharp/DecompressionStream.cs
@@ -79,7 +79,10 @@ namespace ZstdSharp
             }
             decompressor = null;
 
-            ArrayPool<byte>.Shared.Return(inputBuffer);
+            if (inputBuffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(inputBuffer);
+            }
 
             if (!leaveOpen)
             {


### PR DESCRIPTION
This PR only returns the `outputBuffer` and `inputBuffer` in `CompressionStream` and `DecompressionStream` respectively when they are not `null`.

They are `null` in an edge case where the `ArrayPool<byte>.Shared.Rent(..)` call in the constructor throws an exception. Specifically when it throws an `OutOfMemoryException`.
This exception can be caught and handled (unlike other OOMs), however the process will crash due to the implementation of `CompressionStream` and `DecompressionStream`.

The instance was not disposed (since the constructor threw an exception).
Hence, the finalizer thread will try to call the destructors that call `Dispose(false)` and eventually reach `ArrayPool<byte>.Shared.Return(..)`.
This call will throw with an `ArgumentNullException` which will crash the process (as unhandled exceptions from the finalizer thread do).

Although caught OOMs are an edge case, there's no reason this library should then cause a crash.