### PR TITLE
Remove unnecessary reference to Microsoft.Bcl.AsyncInterfaces.

### DIFF
--- a/src/ZstdSharp/ZstdSharp.csproj
+++ b/src/ZstdSharp/ZstdSharp.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net462'">
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">


### PR DESCRIPTION
Fixes #61 

net462, netstandard2.0
```mermaid
graph TD
    Zstd[ZstdSharp]
    TasksExt["System.Threading.Tasks.Extensions 4.5.4 (4.2.0.1)"]
    Memory["System.Memory 4.5.5 (4.0.1.2)"]
    Unsafe["System.Runtime.CompilerServices.Unsafe 6.0.0 (6.0.0.0)"]
    AsyncIntf["Microsoft.Bcl.AsyncInterfaces 5.0.0 (5.0.0.0)"]

    Zstd -- ">= 4.5.5" --> Memory
    Zstd --> TasksExt
    Zstd -- ">= 6.0.0" --> Unsafe
    Memory -- ">= 4.5.3" --> Unsafe
    TasksExt -- ">= 4.5.3" --> Unsafe
    AsyncIntf -- ">= 4.5.4" --> TasksExt
```