### PR TITLE
Update System.Memory to v4.6.0

### DIFF
--- a/src/ZstdSharp/ZstdSharp.csproj
+++ b/src/ZstdSharp/ZstdSharp.csproj
@@ -31,12 +31,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net462'">
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bring the `System.Memory` version up to the same major/minor version that [`Apache.Arrow.Compression`](https://github.com/apache/arrow-dotnet) uses. `Apache.Arrow.Compression` has `ZstdSharp.Port` as a dependency, therefore this update would add compatibility in downstream projects that cannot utilize assembly binding redirects. 

Specifically, this would allow projects compiled for use in [`Bonsai-Rx`](https://github.com/bonsai-rx/bonsai) to use `Apache.Arrow.Compression`. Without this update, due to the custom dependency resolver that Bonsai uses, there is a run-time exception due to `System.Memory` version mismatches.

Ran all unit tests that are not skipped by default on Windows after updating the version, and all tests passed.