### PR TITLE
Update dependencies

### DIFF
--- a/src/Sandbox/Sandbox.csproj
+++ b/src/Sandbox/Sandbox.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net462</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net48</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 

--- a/src/Zstd.Extern/Zstd.Extern.csproj
+++ b/src/Zstd.Extern/Zstd.Extern.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;netstandard2.0;net462</TargetFrameworks>
-    <LangVersion>9</LangVersion>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1;net48</TargetFrameworks>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZstdSharp.Benchmark/ZstdSharp.Benchmark.csproj
+++ b/src/ZstdSharp.Benchmark/ZstdSharp.Benchmark.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462;net7.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net48</TargetFrameworks>
+    <LangVersion>14</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZstdSharp.Test/ZstdNetSteamingTests.cs
+++ b/src/ZstdSharp.Test/ZstdNetSteamingTests.cs
@@ -48,7 +48,7 @@ namespace ZstdSharp.Test
     public class ZstdNetSteamingTests
     {
         [Fact]
-        public async void StreamingCompressionZeroAndOneByte()
+        public async Task StreamingCompressionZeroAndOneByte()
         {
             var data = new byte[] {0, 0, 0, 1, 2, 3, 4, 0, 0, 0};
 
@@ -57,15 +57,15 @@ namespace ZstdSharp.Test
             {
                 compressionStream.Write(data, 0, 0);
                 compressionStream.Write(ReadOnlySpan<byte>.Empty);
-                await compressionStream.WriteAsync(data, 0, 0);
-                await compressionStream.WriteAsync(ReadOnlyMemory<byte>.Empty);
+                await compressionStream.WriteAsync(data, 0, 0, TestContext.Current.CancellationToken);
+                await compressionStream.WriteAsync(ReadOnlyMemory<byte>.Empty, TestContext.Current.CancellationToken);
 
                 compressionStream.Write(data, 3, 1);
                 compressionStream.Write(new ReadOnlySpan<byte>(data, 4, 1));
                 compressionStream.Flush();
-                await compressionStream.WriteAsync(data, 5, 1);
-                await compressionStream.WriteAsync(new ReadOnlyMemory<byte>(data, 6, 1));
-                await compressionStream.FlushAsync();
+                await compressionStream.WriteAsync(data, 5, 1, TestContext.Current.CancellationToken);
+                await compressionStream.WriteAsync(new ReadOnlyMemory<byte>(data, 6, 1), TestContext.Current.CancellationToken);
+                await compressionStream.FlushAsync(TestContext.Current.CancellationToken);
             }
 
             tempStream.Seek(0, SeekOrigin.Begin);
@@ -75,13 +75,13 @@ namespace ZstdSharp.Test
             {
                 Assert.Equal(0, decompressionStream.Read(result, 0, 0));
                 Assert.Equal(0, decompressionStream.Read(Span<byte>.Empty));
-                Assert.Equal(0, await decompressionStream.ReadAsync(result, 0, 0));
-                Assert.Equal(0, await decompressionStream.ReadAsync(Memory<byte>.Empty));
+                Assert.Equal(0, await decompressionStream.ReadAsync(result, 0, 0, TestContext.Current.CancellationToken));
+                Assert.Equal(0, await decompressionStream.ReadAsync(Memory<byte>.Empty, TestContext.Current.CancellationToken));
 
                 Assert.Equal(1, decompressionStream.Read(result, 3, 1));
                 Assert.Equal(1, decompressionStream.Read(new Span<byte>(result, 4, 1)));
-                Assert.Equal(1, await decompressionStream.ReadAsync(result, 5, 1));
-                Assert.Equal(1, await decompressionStream.ReadAsync(new Memory<byte>(result, 6, 1)));
+                Assert.Equal(1, await decompressionStream.ReadAsync(result, 5, 1, TestContext.Current.CancellationToken));
+                Assert.Equal(1, await decompressionStream.ReadAsync(new Memory<byte>(result, 6, 1), TestContext.Current.CancellationToken));
             }
 
             Assert.True(data.SequenceEqual(result));
@@ -346,8 +346,8 @@ namespace ZstdSharp.Test
                 }
 
                 int bytesRead;
-                while ((bytesRead = await testStream.ReadAsync(buffer, offset, copyBufferSize)) > 0)
-                    await compressionStream.WriteAsync(buffer, offset, bytesRead);
+                while ((bytesRead = await testStream.ReadAsync(buffer, offset, copyBufferSize, TestContext.Current.CancellationToken)) > 0)
+                    await compressionStream.WriteAsync(buffer, offset, bytesRead, TestContext.Current.CancellationToken);
             }
 
             tempStream.Seek(0, SeekOrigin.Begin);
@@ -362,8 +362,8 @@ namespace ZstdSharp.Test
                 }
 
                 int bytesRead;
-                while ((bytesRead = await decompressionStream.ReadAsync(buffer, offset, copyBufferSize)) > 0)
-                    await resultStream.WriteAsync(buffer, offset, bytesRead);
+                while ((bytesRead = await decompressionStream.ReadAsync(buffer, offset, copyBufferSize, TestContext.Current.CancellationToken)) > 0)
+                    await resultStream.WriteAsync(buffer, offset, bytesRead, TestContext.Current.CancellationToken);
             }
 
             Assert.True(testStream.ToArray().SequenceEqual(resultStream.ToArray()));
@@ -409,15 +409,15 @@ namespace ZstdSharp.Test
             using (var decomp = new DecompressionStream(pipeClient))
             {
                 var data = new byte[] { 0, 1, 2 };
-                await comp.WriteAsync(data);
-                await comp.FlushAsync();
+                await comp.WriteAsync(data, TestContext.Current.CancellationToken);
+                await comp.FlushAsync(TestContext.Current.CancellationToken);
 
                 var buf = new byte[outputBufSize];
 
                 var received = new List<byte>();
                 while (received.Count < data.Length)
                 {
-                    var count = await decomp.ReadAsync(buf);
+                    var count = await decomp.ReadAsync(buf, TestContext.Current.CancellationToken);
                     received.AddRange(buf.Take(count));
                 }
 
@@ -518,8 +518,8 @@ namespace ZstdSharp.Test
             var bs = new BufferedStream(ms, 4096);
             using var writer = new CompressionStream(bs);
             var src = new byte[1] { 42 };
-            await writer.WriteAsync(src);
-            await writer.FlushAsync();
+            await writer.WriteAsync(src, TestContext.Current.CancellationToken);
+            await writer.FlushAsync(TestContext.Current.CancellationToken);
             Assert.True(ms.ToArray().Length > 0);
         }
 
@@ -530,7 +530,7 @@ namespace ZstdSharp.Test
             var bs = new BufferedStream(ms, 4096);
             using var writer = new CompressionStream(bs, leaveOpen: true);
             var src = new byte[1] { 42 };
-            await writer.WriteAsync(src);
+            await writer.WriteAsync(src, TestContext.Current.CancellationToken);
             await writer.DisposeAsync();
             Assert.True(ms.ToArray().Length == 0);
             bs.Dispose();

--- a/src/ZstdSharp.Test/ZstdSharp.Test.csproj
+++ b/src/ZstdSharp.Test/ZstdSharp.Test.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net462</TargetFrameworks>
+	<OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net48</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <IsPackable>false</IsPackable>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -15,14 +16,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="Xunit.Combinatorial" Version="1.6.24" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="Xunit.Combinatorial" Version="2.0.24" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ZstdSharp/CompressionStream.cs
+++ b/src/ZstdSharp/CompressionStream.cs
@@ -147,7 +147,7 @@ namespace ZstdSharp
         {
             EnsureNotDisposed();
 
-            var input = new ZSTD_inBuffer_s {pos = 0, size = buffer != null ? (nuint) buffer.Length : 0};
+            var input = new ZSTD_inBuffer_s {pos = 0, size = (nuint)buffer.Length};
             nuint remaining;
             do
             {

--- a/src/ZstdSharp/Unsafe/Bitstream.cs
+++ b/src/ZstdSharp/Unsafe/Bitstream.cs
@@ -370,7 +370,6 @@ namespace ZstdSharp.Unsafe
         {
             if (bitD->bitsConsumed > (uint)(sizeof(nuint) * 8))
             {
-                const nuint zeroFilled = 0;
                 bitD->ptr = (sbyte*)&static_zeroFilled[0];
                 return BIT_DStream_status.BIT_DStream_overflow;
             }
@@ -563,7 +562,6 @@ namespace ZstdSharp.Unsafe
         {
             if (bitD_bitsConsumed > (uint)(sizeof(nuint) * 8))
             {
-                const nuint zeroFilled = 0;
                 bitD_ptr = (sbyte*)&static_zeroFilled[0];
                 return BIT_DStream_status.BIT_DStream_overflow;
             }

--- a/src/ZstdSharp/Unsafe/HufDecompress.cs
+++ b/src/ZstdSharp/Unsafe/HufDecompress.cs
@@ -504,7 +504,6 @@ namespace ZstdSharp.Unsafe
             for (; ; )
             {
                 byte* olimit;
-                int stream;
                 {
                     assert(op0 <= op1);
                     assert(ip0 >= ilowest);
@@ -1446,7 +1445,6 @@ namespace ZstdSharp.Unsafe
             for (; ; )
             {
                 byte* olimit;
-                int stream;
                 {
                     assert(op0 <= oend0);
                     assert(ip0 >= ilowest);

--- a/src/ZstdSharp/Unsafe/ZstdDecompressBlock.cs
+++ b/src/ZstdSharp/Unsafe/ZstdDecompressBlock.cs
@@ -1412,7 +1412,7 @@ namespace ZstdSharp.Unsafe
         private static nuint ZSTD_decompressSequences_body(ZSTD_DCtx_s* dctx, void* dst, nuint maxDstSize, void* seqStart, nuint seqSize, int nbSeq, ZSTD_longOffset_e isLongOffset)
         {
             // HACK, force nbSeq to stack (better register usage)
-            System.Threading.Thread.VolatileRead(ref nbSeq);
+            System.Threading.Volatile.Read(ref nbSeq);
             byte* ip = (byte*)seqStart;
             byte* iend = ip + seqSize;
             byte* ostart = (byte*)dst;

--- a/src/ZstdSharp/ZstdSharp.csproj
+++ b/src/ZstdSharp/ZstdSharp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1;net48</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <Authors>Oleg Stepanischev</Authors>
@@ -20,6 +20,10 @@
     <Version>0.8.7</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>TRACE</DefineConstants>
@@ -30,22 +34,22 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net462'">
-    <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='net48'">
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net5.0'))">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fody" Version="6.9.1">
+    <PackageReference Include="Fody" Version="6.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="InlineMethod.Fody" Version="0.8.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="InlineMethod.Fody" Version="0.8.7" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi. This pull request makes several changes, so I've summarised the changes for each file below.

- Changes the target frameworks to remove obsolete frameworks like `netcoreapp3.1` and switches to `net8.0`, `net9.0`, `net10.0`, `netstandard2.0`, `netstandard2.1`, `net48`.
  - This should not remove support for any frameworks, due to .NET Standard 2.0 supporting .NET Framework 4.6.2 (the oldest framework previously supported).
- Updated the package dependencies of each project.
- Several fixes for warnings by VS2026.

**Summary for each file:**

`src/Sandbox/Sandbox.csproj`:
- Changed target frameworks to .NET Framework 4.8, .NET 8.0, .NET 9.0, .NET 10.0
- Changed language version to 14 (latest)

`src\Zstd.Extern\Zstd.Extern.csproj`:
- Changed target frameworks to .NET Standard 2.0, .NET Standard 2.1, .NET Framework 4.8, .NET 8.0, .NET 9.0, .NET 10.0
- Changed language version to 14 (latest)
- Enabled `IsAotCompatible` for .NET 8.0 and higher

`src\ZstdSharp.Benchmark\ZstdSharp.Benchmark.csproj`:
- Changed target frameworks to .NET Framework 4.8, .NET 8.0, .NET 9.0, .NET 10.0
- Changed language version to 14 (latest)
- Updated benchmark packages

`src\ZstdSharp.Test\ZstdNetSteamingTests.cs`:
- Changed `async void` to `async Test` to be compatible with xUnit v3
- Passed test cancellation token to methods accepting cancellation token (to fix warnings produced by xUnit v3)

`src\ZstdSharp.Test\ZstdSharp.Test.csproj`:
- Changed target frameworks to .NET Framework 4.8, .NET 8.0, .NET 9.0, .NET 10.0
- Changed language version to 14 (latest)
- Updated test packages, including updating from xUnit (deprecated) to xUnit v3

`src\ZstdSharp\CompressionStream.cs`:
- Fixed warning that null check is redundant by removing unnecessary null check (spans cannot be null as they are structs - passing a null array creates an empty span, so behaviour here will be the same)

`src\ZstdSharp\Unsafe\Bitstream.cs`:
- Removed unused local variables

`src\ZstdSharp\Unsafe\HufDecompress.cs`:
- Removed unused local variables

`src\ZstdSharp\Unsafe\ZstdDecompressBlock.cs`:
- Replaced deprecated `Thread.VolatileRead` with `Volatile.Read` (`Thread.VolatileRead` just calls `Volatile.Read`)

`src\ZstdSharp\ZstdSharp.csproj`:
- Changed target frameworks to .NET Standard 2.0, .NET Standard 2.1, .NET Framework 4.8, .NET 8.0, .NET 9.0, .NET 10.0
- Changed language version to 14 (latest)
- Enabled `IsAotCompatible` for .NET 8.0 and higher
- Updated packages

Following this pull request, all tests pass for me. Let me know if you disagree with one of the changes made here.

*Note: This pull request was hand-written by myself, not created with AI.*