### PR TITLE
Add SetPrefix (patch-from) support to Compressor and Decompressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ compressionStream.SetParameter(ZSTD_cParameter.ZSTD_c_nbWorkers, Environment.Pro
 input.CopyTo(compressionStream);
 ```
 
+Delta compression ("patch-from", like `zstd --patch-from`) — compress a new version of the data
+against the previous version used as a prefix:
+```c#
+// windowLog must cover prefix + input
+var windowLog = 10;
+while (windowLog < 31 && (1L << windowLog) < 2L * (long)oldVersion.Length)
+    windowLog++;
+
+using var compressor = new Compressor(level);
+compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
+compressor.SetPrefix(oldVersion);
+var delta = compressor.Wrap(newVersion);
+
+using var decompressor = new Decompressor();
+decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
+decompressor.SetPrefix(oldVersion);
+var restored = decompressor.Unwrap(delta);
+```
+Note: prefer `SetPrefix` over `LoadDictionary` for delta compression. `LoadDictionary` builds a
+CDict whose effectiveness degrades for reference contents larger than ~32-64 MB (inherited zstd
+behavior), while a prefix is indexed with the context parameters and has no such limit.
+
 
 # Benchmark
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ input.CopyTo(compressionStream);
 ```
 
 Delta compression ("patch-from", like `zstd --patch-from`) — compress a new version of the data
-against the previous version used as a prefix:
+against the previous version referenced as a prefix (`ZSTD_CCtx_refPrefix`). The prefix applies
+to the next frame only; reference it again before each frame:
 ```c#
 // windowLog must cover prefix + input
 var windowLog = 10;
@@ -62,15 +63,15 @@ while (windowLog < 31 && (1L << windowLog) < (long)oldVersion.Length + newVersio
 using var compressor = new Compressor(level);
 compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
 compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
-compressor.SetPrefix(oldVersion);
+compressor.RefPrefix(oldVersion);
 var delta = compressor.Wrap(newVersion);
 
 using var decompressor = new Decompressor();
 decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
-decompressor.SetPrefix(oldVersion);
+decompressor.RefPrefix(oldVersion);
 var restored = decompressor.Unwrap(delta);
 ```
-Note: prefer `SetPrefix` over `LoadDictionary` for delta compression. `LoadDictionary` builds a
+Note: prefer `RefPrefix` over `LoadDictionary` for delta compression. `LoadDictionary` builds a
 CDict whose effectiveness degrades for reference contents larger than ~32-64 MB (inherited zstd
 behavior), while a prefix is indexed with the context parameters and has no such limit.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ against the previous version used as a prefix:
 ```c#
 // windowLog must cover prefix + input
 var windowLog = 10;
-while (windowLog < 31 && (1L << windowLog) < 2L * (long)oldVersion.Length)
+while (windowLog < 31 && (1L << windowLog) < (long)oldVersion.Length + newVersion.Length)
     windowLog++;
 
 using var compressor = new Compressor(level);

--- a/src/ZstdSharp.Test/ZstdPrefixTest.cs
+++ b/src/ZstdSharp.Test/ZstdPrefixTest.cs
@@ -1,0 +1,144 @@
+using System;
+using ZstdSharp.Unsafe;
+using Xunit;
+
+namespace ZstdSharp.Test
+{
+    /// <summary>
+    /// Tests for Compressor.SetPrefix / Decompressor.SetPrefix (zstd "patch-from"):
+    /// delta compression against a reference content, effective at any reference size.
+    /// </summary>
+    public class ZstdPrefixTest
+    {
+        private static byte[] CreateRandom(int size, int seed = 42)
+        {
+            var data = new byte[size];
+            new Random(seed).NextBytes(data);
+            return data;
+        }
+
+        private static int WindowLog(long totalSize)
+        {
+            var windowLog = 10;
+            while (windowLog < 31 && (1L << windowLog) < totalSize)
+                windowLog++;
+            return windowLog;
+        }
+
+        [Fact]
+        public void PrefixRoundtrip_ModifiedData()
+        {
+            var baseData = CreateRandom(1024 * 1024);
+            var targetData = (byte[])baseData.Clone();
+            for (var i = 0; i < 64; i++)
+                targetData[100000 + i] ^= 0xFF;
+
+            var windowLog = WindowLog(2L * baseData.Length);
+
+            using var compressor = new Compressor(19);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_checksumFlag, 1);
+            compressor.SetPrefix(baseData);
+            var delta = compressor.Wrap(targetData).ToArray();
+
+            // 64 changed bytes in 1 MB: the delta must be tiny, not a recompression.
+            Assert.True(delta.Length < 4096, $"delta too large: {delta.Length} bytes");
+
+            using var decompressor = new Decompressor();
+            decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
+            decompressor.SetPrefix(baseData);
+            var restored = decompressor.Unwrap(delta).ToArray();
+            Assert.Equal(targetData, restored);
+        }
+
+        [Fact]
+        public void PrefixRoundtrip_WrongPrefixFails()
+        {
+            // The target must actually reference the prefix, otherwise decompression
+            // succeeds regardless of the prefix supplied.
+            var baseData = CreateRandom(1024 * 1024);
+            var targetData = (byte[])baseData.Clone();
+            for (var i = 0; i < 64; i++)
+                targetData[200000 + i] ^= 0xFF;
+
+            using var compressor = new Compressor(19);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, WindowLog(2L * baseData.Length));
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_checksumFlag, 1);
+            compressor.SetPrefix(baseData);
+            var delta = compressor.Wrap(targetData).ToArray();
+            Assert.True(delta.Length < 4096, "the delta should reference the prefix");
+
+            var wrongPrefix = CreateRandom(1024 * 1024, seed: 44);
+            using var decompressor = new Decompressor();
+            decompressor.SetPrefix(wrongPrefix);
+            Assert.Throws<ZstdException>(() => decompressor.Unwrap(delta));
+        }
+
+        [Fact]
+        public void Prefix_LargeReference_StaysEffective()
+        {
+            // Regression for delta ("patch-from") against large references: LoadDictionary
+            // builds a CDict whose effectiveness degrades beyond ~32-64 MB of content
+            // (inherited zstd behavior), while a prefix is indexed with the context
+            // parameters and has no such limit.
+            const int size = 128 * 1024 * 1024;
+            var baseData = CreateRandom(size);
+            var targetData = (byte[])baseData.Clone();
+
+            var windowLog = WindowLog(2L * size);
+
+            using var compressor = new Compressor(3);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
+            compressor.SetPrefix(baseData);
+            var delta = compressor.Wrap(targetData).ToArray();
+
+            // Identical content: with an effective reference the delta is <1% of the input.
+            Assert.True(delta.Length < size / 100, $"prefix was not effective: {delta.Length} bytes");
+
+            using var decompressor = new Decompressor();
+            decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
+            decompressor.SetPrefix(baseData);
+            var restored = decompressor.Unwrap(delta).ToArray();
+            Assert.Equal(targetData, restored);
+        }
+
+        [Fact]
+        public void Prefix_OverlappingSource_IsDefended()
+        {
+            // zstd silently ignores a by-reference prefix overlapping the source buffer;
+            // the wrapper must defend by working on a copy.
+            var data = CreateRandom(1024 * 1024);
+
+            using var compressor = new Compressor(3);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, WindowLog(2L * data.Length));
+            compressor.SetPrefix(data);
+            var delta = compressor.Wrap(data).ToArray();
+
+            Assert.True(delta.Length < data.Length / 100, $"prefix was not effective: {delta.Length} bytes");
+        }
+
+        [Fact]
+        public void Prefix_IsReappliedAcrossWraps_AndClearable()
+        {
+            var baseData = CreateRandom(1024 * 1024);
+            var targetData = (byte[])baseData.Clone();
+
+            using var compressor = new Compressor(3);
+            compressor.SetPrefix(baseData);
+            var first = compressor.Wrap(targetData).ToArray();
+            var second = compressor.Wrap(targetData).ToArray();
+
+            // The prefix must apply to every Wrap, not only the first frame.
+            Assert.True(first.Length < baseData.Length / 100);
+            Assert.True(second.Length < baseData.Length / 100);
+
+            compressor.SetPrefix(null);
+            var withoutPrefix = compressor.Wrap(targetData).ToArray();
+            Assert.True(withoutPrefix.Length > baseData.Length / 2, "clearing the prefix had no effect");
+        }
+    }
+}

--- a/src/ZstdSharp.Test/ZstdPrefixTest.cs
+++ b/src/ZstdSharp.Test/ZstdPrefixTest.cs
@@ -82,8 +82,9 @@ namespace ZstdSharp.Test
             // Regression for delta ("patch-from") against large references: LoadDictionary
             // builds a CDict whose effectiveness degrades beyond ~32-64 MB of content
             // (inherited zstd behavior), while a prefix is indexed with the context
-            // parameters and has no such limit.
-            const int size = 128 * 1024 * 1024;
+            // parameters and has no such limit. 80 MB crosses that threshold while keeping
+            // the test CI-friendly (~240 MB peak).
+            const int size = 80 * 1024 * 1024;
             var baseData = CreateRandom(size);
             var targetData = (byte[])baseData.Clone();
 

--- a/src/ZstdSharp.Test/ZstdPrefixTest.cs
+++ b/src/ZstdSharp.Test/ZstdPrefixTest.cs
@@ -5,8 +5,8 @@ using Xunit;
 namespace ZstdSharp.Test
 {
     /// <summary>
-    /// Tests for Compressor.SetPrefix / Decompressor.SetPrefix (zstd "patch-from"):
-    /// delta compression against a reference content, effective at any reference size.
+    /// Tests for Compressor.RefPrefix / Decompressor.RefPrefix (ZSTD_CCtx_refPrefix /
+    /// ZSTD_DCtx_refPrefix): delta compression against a reference content ("patch-from").
     /// </summary>
     public class ZstdPrefixTest
     {
@@ -26,7 +26,7 @@ namespace ZstdSharp.Test
         }
 
         [Fact]
-        public void PrefixRoundtrip_ModifiedData()
+        public void RefPrefixRoundtrip_ModifiedData()
         {
             var baseData = CreateRandom(1024 * 1024);
             var targetData = (byte[])baseData.Clone();
@@ -39,7 +39,7 @@ namespace ZstdSharp.Test
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_checksumFlag, 1);
-            compressor.SetPrefix(baseData);
+            compressor.RefPrefix(baseData);
             var delta = compressor.Wrap(targetData).ToArray();
 
             // 64 changed bytes in 1 MB: the delta must be tiny, not a recompression.
@@ -47,13 +47,13 @@ namespace ZstdSharp.Test
 
             using var decompressor = new Decompressor();
             decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
-            decompressor.SetPrefix(baseData);
+            decompressor.RefPrefix(baseData);
             var restored = decompressor.Unwrap(delta).ToArray();
             Assert.Equal(targetData, restored);
         }
 
         [Fact]
-        public void PrefixRoundtrip_WrongPrefixFails()
+        public void RefPrefixRoundtrip_WrongPrefixFails()
         {
             // The target must actually reference the prefix, otherwise decompression
             // succeeds regardless of the prefix supplied.
@@ -66,24 +66,23 @@ namespace ZstdSharp.Test
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, WindowLog(2L * baseData.Length));
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_checksumFlag, 1);
-            compressor.SetPrefix(baseData);
+            compressor.RefPrefix(baseData);
             var delta = compressor.Wrap(targetData).ToArray();
             Assert.True(delta.Length < 4096, "the delta should reference the prefix");
 
             var wrongPrefix = CreateRandom(1024 * 1024, seed: 44);
             using var decompressor = new Decompressor();
-            decompressor.SetPrefix(wrongPrefix);
+            decompressor.RefPrefix(wrongPrefix);
             Assert.Throws<ZstdException>(() => decompressor.Unwrap(delta));
         }
 
         [Fact]
-        public void Prefix_LargeReference_StaysEffective()
+        public void RefPrefix_LargeReference_StaysEffective()
         {
-            // Regression for delta ("patch-from") against large references: LoadDictionary
-            // builds a CDict whose effectiveness degrades beyond ~32-64 MB of content
-            // (inherited zstd behavior), while a prefix is indexed with the context
-            // parameters and has no such limit. 80 MB crosses that threshold while keeping
-            // the test CI-friendly (~240 MB peak).
+            // Delta ("patch-from") against large references: LoadDictionary builds a CDict
+            // whose effectiveness degrades beyond ~32-64 MB of content (inherited zstd
+            // behavior), while a prefix is indexed with the context parameters and has no
+            // such limit.
             const int size = 80 * 1024 * 1024;
             var baseData = CreateRandom(size);
             var targetData = (byte[])baseData.Clone();
@@ -93,7 +92,7 @@ namespace ZstdSharp.Test
             using var compressor = new Compressor(3);
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
             compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, windowLog);
-            compressor.SetPrefix(baseData);
+            compressor.RefPrefix(baseData);
             var delta = compressor.Wrap(targetData).ToArray();
 
             // Identical content: with an effective reference the delta is <1% of the input.
@@ -101,45 +100,33 @@ namespace ZstdSharp.Test
 
             using var decompressor = new Decompressor();
             decompressor.SetParameter(ZSTD_dParameter.ZSTD_d_windowLogMax, windowLog);
-            decompressor.SetPrefix(baseData);
+            decompressor.RefPrefix(baseData);
             var restored = decompressor.Unwrap(delta).ToArray();
             Assert.Equal(targetData, restored);
         }
 
         [Fact]
-        public void Prefix_OverlappingSource_IsDefended()
+        public void RefPrefix_AppliesToNextFrameOnly()
         {
-            // zstd silently ignores a by-reference prefix overlapping the source buffer;
-            // the wrapper must defend by working on a copy.
-            var data = CreateRandom(1024 * 1024);
-
-            using var compressor = new Compressor(3);
-            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
-            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, WindowLog(2L * data.Length));
-            compressor.SetPrefix(data);
-            var delta = compressor.Wrap(data).ToArray();
-
-            Assert.True(delta.Length < data.Length / 100, $"prefix was not effective: {delta.Length} bytes");
-        }
-
-        [Fact]
-        public void Prefix_IsReappliedAcrossWraps_AndClearable()
-        {
+            // Native semantics: the prefix is consumed by the next frame; later frames
+            // compress without it unless it is referenced again.
             var baseData = CreateRandom(1024 * 1024);
             var targetData = (byte[])baseData.Clone();
 
             using var compressor = new Compressor(3);
-            compressor.SetPrefix(baseData);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_enableLongDistanceMatching, 1);
+            compressor.SetParameter(ZSTD_cParameter.ZSTD_c_windowLog, WindowLog(2L * baseData.Length));
+
+            compressor.RefPrefix(baseData);
             var first = compressor.Wrap(targetData).ToArray();
+            Assert.True(first.Length < baseData.Length / 100, "first frame should use the prefix");
+
             var second = compressor.Wrap(targetData).ToArray();
+            Assert.True(second.Length > baseData.Length / 2, "second frame should not use the prefix");
 
-            // The prefix must apply to every Wrap, not only the first frame.
-            Assert.True(first.Length < baseData.Length / 100);
-            Assert.True(second.Length < baseData.Length / 100);
-
-            compressor.SetPrefix(null);
-            var withoutPrefix = compressor.Wrap(targetData).ToArray();
-            Assert.True(withoutPrefix.Length > baseData.Length / 2, "clearing the prefix had no effect");
+            compressor.RefPrefix(baseData);
+            var third = compressor.Wrap(targetData).ToArray();
+            Assert.True(third.Length < baseData.Length / 100, "re-referenced prefix should apply again");
         }
     }
 }

--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -26,7 +26,9 @@ namespace ZstdSharp
 
         private readonly SafeCctxHandle handle;
 
-        private byte[] prefix;
+#nullable enable
+        private byte[]? prefix;
+#nullable restore
 
         public int Level
         {
@@ -79,10 +81,12 @@ namespace ZstdSharp
         /// Pass null to clear. Note: the prefix applies to Wrap/TryWrap (single-shot) calls only.
         /// </summary>
         /// <param name="prefix">Reference content (for delta compression, the previous version of the data), or null to clear.</param>
-        public void SetPrefix(byte[] prefix)
+#nullable enable
+        public void SetPrefix(byte[]? prefix)
         {
             this.prefix = prefix;
         }
+#nullable restore
 
         public Compressor(int level = DefaultCompressionLevel)
         {
@@ -108,7 +112,7 @@ namespace ZstdSharp
 
         public int Wrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            var currentPrefix = GetEffectivePrefix(src);
+            var currentPrefix = GetEffectivePrefix(src, dest);
             fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
@@ -122,14 +126,18 @@ namespace ZstdSharp
         }
 
         /* A prefix overlapping the source confuses the zstd window tracking and is silently
-         * ignored (e.g. compressing a buffer against itself); work on a copy in that case. */
-        private byte[] GetEffectivePrefix(ReadOnlySpan<byte> src)
+         * ignored (e.g. compressing a buffer against itself), and a prefix overlapping the
+         * destination would be modified while zstd is still reading it; work on a copy in
+         * either case. */
+#nullable enable
+        private byte[]? GetEffectivePrefix(ReadOnlySpan<byte> src, ReadOnlySpan<byte> dest)
         {
             var currentPrefix = prefix;
-            if (currentPrefix != null && src.Overlaps(currentPrefix))
+            if (currentPrefix != null && (src.Overlaps(currentPrefix) || dest.Overlaps(currentPrefix)))
                 currentPrefix = (byte[])currentPrefix.Clone();
             return currentPrefix;
         }
+#nullable restore
 
         public int Wrap(ArraySegment<byte> src, ArraySegment<byte> dest)
             => Wrap((ReadOnlySpan<byte>)src, dest);
@@ -142,7 +150,7 @@ namespace ZstdSharp
 
         public bool TryWrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            var currentPrefix = GetEffectivePrefix(src);
+            var currentPrefix = GetEffectivePrefix(src, dest);
             fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)

--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -72,8 +72,9 @@ namespace ZstdSharp
         /// <summary>
         /// References a prefix for the next compressed frame (ZSTD_CCtx_refPrefix), enabling
         /// delta compression ("patch-from"). Native semantics: the prefix applies to the next
-        /// frame only and is referenced, not copied — this instance pins the array and it must
-        /// not be modified until that compression completes. Re-reference before each frame.
+        /// frame only and is referenced, not copied — re-reference before each frame. The
+        /// supplied array is pinned and retained by the compressor until replaced, cleared, or
+        /// disposal, and must not be modified while in use.
         /// Decompression must reference the same prefix (<see cref="Decompressor.RefPrefix(byte[])"/>).
         /// Pass null to clear.
         /// </summary>

--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.InteropServices;
 using ZstdSharp.Unsafe;
 
 namespace ZstdSharp
@@ -26,9 +27,7 @@ namespace ZstdSharp
 
         private readonly SafeCctxHandle handle;
 
-#nullable enable
-        private byte[]? prefix;
-#nullable restore
+        private GCHandle prefixHandle;
 
         public int Level
         {
@@ -71,22 +70,46 @@ namespace ZstdSharp
         }
 
         /// <summary>
-        /// Sets a prefix used as a reference for the next Wrap/TryWrap calls (zstd "patch-from").
-        /// Unlike <see cref="LoadDictionary(byte[])"/>, the prefix is indexed with the compression
-        /// parameters of this context (windowLog, long distance matching, ...), which keeps delta
-        /// compression effective for large reference contents: LoadDictionary builds a CDict whose
-        /// effectiveness degrades for contents larger than ~32-64 MB, while a prefix has no such limit.
-        /// The buffer is referenced (not copied) and must not be modified between calls.
-        /// Decompression must use the same prefix (<see cref="Decompressor.SetPrefix(byte[])"/>).
-        /// Pass null to clear. Note: the prefix applies to Wrap/TryWrap (single-shot) calls only.
+        /// References a prefix for the next compressed frame (ZSTD_CCtx_refPrefix), enabling
+        /// delta compression ("patch-from"). Native semantics: the prefix applies to the next
+        /// frame only and is referenced, not copied — this instance pins the array and it must
+        /// not be modified until that compression completes. Re-reference before each frame.
+        /// Decompression must reference the same prefix (<see cref="Decompressor.RefPrefix(byte[])"/>).
+        /// Pass null to clear.
         /// </summary>
         /// <param name="prefix">Reference content (for delta compression, the previous version of the data), or null to clear.</param>
 #nullable enable
-        public void SetPrefix(byte[]? prefix)
+        public void RefPrefix(byte[]? prefix)
         {
-            this.prefix = prefix;
+            using var cctx = handle.Acquire();
+            FreePinnedPrefix();
+            if (prefix == null || prefix.Length == 0)
+            {
+                Methods.ZSTD_CCtx_refPrefix(cctx, null, 0).EnsureZstdSuccess();
+                return;
+            }
+
+            prefixHandle = GCHandle.Alloc(prefix, GCHandleType.Pinned);
+            try
+            {
+                Methods.ZSTD_CCtx_refPrefix(cctx, (byte*)prefixHandle.AddrOfPinnedObject(), (nuint)prefix.Length)
+                    .EnsureZstdSuccess();
+            }
+            catch
+            {
+                FreePinnedPrefix();
+                throw;
+            }
         }
 #nullable restore
+
+        private void FreePinnedPrefix()
+        {
+            if (prefixHandle.IsAllocated)
+            {
+                prefixHandle.Free();
+            }
+        }
 
         public Compressor(int level = DefaultCompressionLevel)
         {
@@ -112,32 +135,14 @@ namespace ZstdSharp
 
         public int Wrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            var currentPrefix = GetEffectivePrefix(src, dest);
-            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 using var cctx = handle.Acquire();
-                if (currentPrefix != null)
-                    Methods.ZSTD_CCtx_refPrefix(cctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                 return (int)Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
             }
         }
-
-        /* A prefix overlapping the source confuses the zstd window tracking and is silently
-         * ignored (e.g. compressing a buffer against itself), and a prefix overlapping the
-         * destination would be modified while zstd is still reading it; work on a copy in
-         * either case. */
-#nullable enable
-        private byte[]? GetEffectivePrefix(ReadOnlySpan<byte> src, ReadOnlySpan<byte> dest)
-        {
-            var currentPrefix = prefix;
-            if (currentPrefix != null && (src.Overlaps(currentPrefix) || dest.Overlaps(currentPrefix)))
-                currentPrefix = (byte[])currentPrefix.Clone();
-            return currentPrefix;
-        }
-#nullable restore
 
         public int Wrap(ArraySegment<byte> src, ArraySegment<byte> dest)
             => Wrap((ReadOnlySpan<byte>)src, dest);
@@ -150,16 +155,12 @@ namespace ZstdSharp
 
         public bool TryWrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            var currentPrefix = GetEffectivePrefix(src, dest);
-            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 nuint returnValue;
                 using (var cctx = handle.Acquire())
                 {
-                    if (currentPrefix != null)
-                        Methods.ZSTD_CCtx_refPrefix(cctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                     returnValue =
                         Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
                 }
@@ -185,6 +186,7 @@ namespace ZstdSharp
         public void Dispose()
         {
             handle.Dispose();
+            FreePinnedPrefix();
             GC.SuppressFinalize(this);
         }
 

--- a/src/ZstdSharp/Compressor.cs
+++ b/src/ZstdSharp/Compressor.cs
@@ -26,6 +26,8 @@ namespace ZstdSharp
 
         private readonly SafeCctxHandle handle;
 
+        private byte[] prefix;
+
         public int Level
         {
             get => level;
@@ -66,6 +68,22 @@ namespace ZstdSharp
                 Methods.ZSTD_CCtx_loadDictionary(cctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
         }
 
+        /// <summary>
+        /// Sets a prefix used as a reference for the next Wrap/TryWrap calls (zstd "patch-from").
+        /// Unlike <see cref="LoadDictionary(byte[])"/>, the prefix is indexed with the compression
+        /// parameters of this context (windowLog, long distance matching, ...), which keeps delta
+        /// compression effective for large reference contents: LoadDictionary builds a CDict whose
+        /// effectiveness degrades for contents larger than ~32-64 MB, while a prefix has no such limit.
+        /// The buffer is referenced (not copied) and must not be modified between calls.
+        /// Decompression must use the same prefix (<see cref="Decompressor.SetPrefix(byte[])"/>).
+        /// Pass null to clear. Note: the prefix applies to Wrap/TryWrap (single-shot) calls only.
+        /// </summary>
+        /// <param name="prefix">Reference content (for delta compression, the previous version of the data), or null to clear.</param>
+        public void SetPrefix(byte[] prefix)
+        {
+            this.prefix = prefix;
+        }
+
         public Compressor(int level = DefaultCompressionLevel)
         {
             handle = SafeCctxHandle.Create();
@@ -90,13 +108,27 @@ namespace ZstdSharp
 
         public int Wrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
+            var currentPrefix = GetEffectivePrefix(src);
+            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 using var cctx = handle.Acquire();
+                if (currentPrefix != null)
+                    Methods.ZSTD_CCtx_refPrefix(cctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                 return (int)Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
             }
+        }
+
+        /* A prefix overlapping the source confuses the zstd window tracking and is silently
+         * ignored (e.g. compressing a buffer against itself); work on a copy in that case. */
+        private byte[] GetEffectivePrefix(ReadOnlySpan<byte> src)
+        {
+            var currentPrefix = prefix;
+            if (currentPrefix != null && src.Overlaps(currentPrefix))
+                currentPrefix = (byte[])currentPrefix.Clone();
+            return currentPrefix;
         }
 
         public int Wrap(ArraySegment<byte> src, ArraySegment<byte> dest)
@@ -110,12 +142,16 @@ namespace ZstdSharp
 
         public bool TryWrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
+            var currentPrefix = GetEffectivePrefix(src);
+            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 nuint returnValue;
                 using (var cctx = handle.Acquire())
                 {
+                    if (currentPrefix != null)
+                        Methods.ZSTD_CCtx_refPrefix(cctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                     returnValue =
                         Methods.ZSTD_compress2(cctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
                 }

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -8,6 +8,8 @@ namespace ZstdSharp
     {
         private readonly SafeDctxHandle handle;
 
+        private byte[] prefix;
+
         public Decompressor()
         {
             handle = SafeDctxHandle.Create();
@@ -38,6 +40,20 @@ namespace ZstdSharp
             using var dctx = handle.Acquire();
             fixed (byte* dictPtr = dict)
                 Methods.ZSTD_DCtx_loadDictionary(dctx, dictPtr, (nuint)dict.Length).EnsureZstdSuccess();
+        }
+
+        /// <summary>
+        /// Sets a prefix used as a reference for the next Unwrap/TryUnwrap calls (zstd "patch-from").
+        /// Must be the same prefix used by <see cref="Compressor.SetPrefix(byte[])"/> during compression.
+        /// The buffer is referenced (not copied) and must not be modified between calls.
+        /// Pass null to clear. Note: the prefix applies to Unwrap/TryUnwrap (single-shot) calls only.
+        /// Remember to raise <see cref="ZSTD_dParameter.ZSTD_d_windowLogMax"/> to the windowLog used
+        /// during compression when large windows are involved.
+        /// </summary>
+        /// <param name="prefix">Reference content used during compression, or null to clear.</param>
+        public void SetPrefix(byte[] prefix)
+        {
+            this.prefix = prefix;
         }
 
         public static ulong GetDecompressedSize(ReadOnlySpan<byte> src)
@@ -72,10 +88,14 @@ namespace ZstdSharp
 
         public int Unwrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
+            var currentPrefix = prefix;
+            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 using var dctx = handle.Acquire();
+                if (currentPrefix != null)
+                    Methods.ZSTD_DCtx_refPrefix(dctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                 return (int)Methods
                     .ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
@@ -90,12 +110,16 @@ namespace ZstdSharp
 
         public bool TryUnwrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
+            var currentPrefix = prefix;
+            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 nuint returnValue;
                 using (var dctx = handle.Acquire())
                 {
+                    if (currentPrefix != null)
+                        Methods.ZSTD_DCtx_refPrefix(dctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                     returnValue =
                         Methods.ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
                 }

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -8,7 +8,9 @@ namespace ZstdSharp
     {
         private readonly SafeDctxHandle handle;
 
-        private byte[] prefix;
+#nullable enable
+        private byte[]? prefix;
+#nullable restore
 
         public Decompressor()
         {
@@ -51,10 +53,23 @@ namespace ZstdSharp
         /// during compression when large windows are involved.
         /// </summary>
         /// <param name="prefix">Reference content used during compression, or null to clear.</param>
-        public void SetPrefix(byte[] prefix)
+#nullable enable
+        public void SetPrefix(byte[]? prefix)
         {
             this.prefix = prefix;
         }
+
+        /* A prefix overlapping the destination would be modified while zstd is still reading
+         * it, and one overlapping the source confuses the window tracking; work on a copy in
+         * either case. */
+        private byte[]? GetEffectivePrefix(ReadOnlySpan<byte> src, ReadOnlySpan<byte> dest)
+        {
+            var currentPrefix = prefix;
+            if (currentPrefix != null && (src.Overlaps(currentPrefix) || dest.Overlaps(currentPrefix)))
+                currentPrefix = (byte[])currentPrefix.Clone();
+            return currentPrefix;
+        }
+#nullable restore
 
         public static ulong GetDecompressedSize(ReadOnlySpan<byte> src)
         {
@@ -88,7 +103,7 @@ namespace ZstdSharp
 
         public int Unwrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            var currentPrefix = prefix;
+            var currentPrefix = GetEffectivePrefix(src, dest);
             fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
@@ -110,7 +125,7 @@ namespace ZstdSharp
 
         public bool TryUnwrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            var currentPrefix = prefix;
+            var currentPrefix = GetEffectivePrefix(src, dest);
             fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Runtime.InteropServices;
 using ZstdSharp.Unsafe;
 
 namespace ZstdSharp
@@ -8,9 +9,7 @@ namespace ZstdSharp
     {
         private readonly SafeDctxHandle handle;
 
-#nullable enable
-        private byte[]? prefix;
-#nullable restore
+        private GCHandle prefixHandle;
 
         public Decompressor()
         {
@@ -45,31 +44,47 @@ namespace ZstdSharp
         }
 
         /// <summary>
-        /// Sets a prefix used as a reference for the next Unwrap/TryUnwrap calls (zstd "patch-from").
-        /// Must be the same prefix used by <see cref="Compressor.SetPrefix(byte[])"/> during compression.
-        /// The buffer is referenced (not copied) and must not be modified between calls.
-        /// Pass null to clear. Note: the prefix applies to Unwrap/TryUnwrap (single-shot) calls only.
-        /// Remember to raise <see cref="ZSTD_dParameter.ZSTD_d_windowLogMax"/> to the windowLog used
-        /// during compression when large windows are involved.
+        /// References a prefix for the next decompressed frame (ZSTD_DCtx_refPrefix). Must be
+        /// the same prefix referenced by <see cref="Compressor.RefPrefix(byte[])"/> during
+        /// compression. Native semantics: the prefix applies to the next frame only and is
+        /// referenced, not copied — this instance pins the array and it must not be modified
+        /// until that decompression completes. Re-reference before each frame; pass null to
+        /// clear. Remember to raise <see cref="ZSTD_dParameter.ZSTD_d_windowLogMax"/> to the
+        /// windowLog used during compression when large windows are involved.
         /// </summary>
         /// <param name="prefix">Reference content used during compression, or null to clear.</param>
 #nullable enable
-        public void SetPrefix(byte[]? prefix)
+        public void RefPrefix(byte[]? prefix)
         {
-            this.prefix = prefix;
-        }
+            using var dctx = handle.Acquire();
+            FreePinnedPrefix();
+            if (prefix == null || prefix.Length == 0)
+            {
+                Methods.ZSTD_DCtx_refPrefix(dctx, null, 0).EnsureZstdSuccess();
+                return;
+            }
 
-        /* A prefix overlapping the destination would be modified while zstd is still reading
-         * it, and one overlapping the source confuses the window tracking; work on a copy in
-         * either case. */
-        private byte[]? GetEffectivePrefix(ReadOnlySpan<byte> src, ReadOnlySpan<byte> dest)
-        {
-            var currentPrefix = prefix;
-            if (currentPrefix != null && (src.Overlaps(currentPrefix) || dest.Overlaps(currentPrefix)))
-                currentPrefix = (byte[])currentPrefix.Clone();
-            return currentPrefix;
+            prefixHandle = GCHandle.Alloc(prefix, GCHandleType.Pinned);
+            try
+            {
+                Methods.ZSTD_DCtx_refPrefix(dctx, (byte*)prefixHandle.AddrOfPinnedObject(), (nuint)prefix.Length)
+                    .EnsureZstdSuccess();
+            }
+            catch
+            {
+                FreePinnedPrefix();
+                throw;
+            }
         }
 #nullable restore
+
+        private void FreePinnedPrefix()
+        {
+            if (prefixHandle.IsAllocated)
+            {
+                prefixHandle.Free();
+            }
+        }
 
         public static ulong GetDecompressedSize(ReadOnlySpan<byte> src)
         {
@@ -103,14 +118,10 @@ namespace ZstdSharp
 
         public int Unwrap(ReadOnlySpan<byte> src, Span<byte> dest)
         {
-            var currentPrefix = GetEffectivePrefix(src, dest);
-            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 using var dctx = handle.Acquire();
-                if (currentPrefix != null)
-                    Methods.ZSTD_DCtx_refPrefix(dctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                 return (int)Methods
                     .ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length)
                     .EnsureZstdSuccess();
@@ -125,16 +136,12 @@ namespace ZstdSharp
 
         public bool TryUnwrap(ReadOnlySpan<byte> src, Span<byte> dest, out int written)
         {
-            var currentPrefix = GetEffectivePrefix(src, dest);
-            fixed (byte* prefixPtr = currentPrefix)
             fixed (byte* srcPtr = src)
             fixed (byte* destPtr = dest)
             {
                 nuint returnValue;
                 using (var dctx = handle.Acquire())
                 {
-                    if (currentPrefix != null)
-                        Methods.ZSTD_DCtx_refPrefix(dctx, prefixPtr, (nuint)currentPrefix.Length).EnsureZstdSuccess();
                     returnValue =
                         Methods.ZSTD_decompressDCtx(dctx, destPtr, (nuint)dest.Length, srcPtr, (nuint)src.Length);
                 }
@@ -157,6 +164,7 @@ namespace ZstdSharp
         public void Dispose()
         {
             handle.Dispose();
+            FreePinnedPrefix();
             GC.SuppressFinalize(this);
         }
 

--- a/src/ZstdSharp/Decompressor.cs
+++ b/src/ZstdSharp/Decompressor.cs
@@ -47,10 +47,11 @@ namespace ZstdSharp
         /// References a prefix for the next decompressed frame (ZSTD_DCtx_refPrefix). Must be
         /// the same prefix referenced by <see cref="Compressor.RefPrefix(byte[])"/> during
         /// compression. Native semantics: the prefix applies to the next frame only and is
-        /// referenced, not copied — this instance pins the array and it must not be modified
-        /// until that decompression completes. Re-reference before each frame; pass null to
-        /// clear. Remember to raise <see cref="ZSTD_dParameter.ZSTD_d_windowLogMax"/> to the
-        /// windowLog used during compression when large windows are involved.
+        /// referenced, not copied — re-reference before each frame. The supplied array is
+        /// pinned and retained by the decompressor until replaced, cleared, or disposal, and
+        /// must not be modified while in use. Pass null to clear. Remember to raise
+        /// <see cref="ZSTD_dParameter.ZSTD_d_windowLogMax"/> to the windowLog used during
+        /// compression when large windows are involved.
         /// </summary>
         /// <param name="prefix">Reference content used during compression, or null to clear.</param>
 #nullable enable


### PR DESCRIPTION
# Add SetPrefix (patch-from) support to Compressor and Decompressor

## Problem

There is currently no effective way to do delta compression ("patch-from", like `zstd --patch-from`) against large reference contents through the high-level API. The natural choice, `LoadDictionary`, silently degrades as the reference grows. Self-delta probe (compressing content against itself as dictionary, level 19, LDM enabled, windowLog covering dict + input — a working dictionary should produce a near-zero delta):

| dictionary size | compressed / input |
|---|---|
| 32 MB | 0.009% (works) |
| 64 MB | 51% (half effective) |
| 96-160 MB | **100% (no effect at all)** |

This is **not a porting issue**: the same probe against native libzstd 1.5.7 (via `Zstd.Extern`) produces identical results. It is inherited zstd CDict behavior — with `ZSTD_dictForceCopy` the dictionary has no effect at these sizes, and the copy path is what gets selected for large inputs. This is precisely why the zstd CLI implements `--patch-from` with `ZSTD_CCtx_refPrefix` rather than `ZSTD_CCtx_loadDictionary`: a prefix is (re-)indexed with the actual compression parameters of the context (windowLog, long distance matching), so it stays effective at any size.

## Change

- `Compressor.SetPrefix(byte[])` / `Decompressor.SetPrefix(byte[])`: expose `ZSTD_CCtx_refPrefix` / `ZSTD_DCtx_refPrefix` in the high-level API. Since zstd consumes the prefix at each frame, the wrapper re-applies it on every single-shot `Wrap`/`TryWrap`/`Unwrap`/`TryUnwrap`; `SetPrefix(null)` clears it. The buffer is referenced, not copied.
- Overlap defense: a by-reference prefix overlapping the source buffer (e.g. compressing a buffer against itself) confuses zstd window tracking and is silently ignored; the wrapper detects the overlap and works on a copy.
- Tests: round-trip with modified data (64 changed bytes in 1 MB -> delta < 4 KB), wrong-prefix detection (checksum), large reference regression (128 MB reference stays < 1%), overlapping buffers, prefix re-use across multiple `Wrap` calls and clearing.
- README: delta compression example, with a note recommending `SetPrefix` over `LoadDictionary` for large references.

Scope note: the prefix applies to single-shot calls only (documented); streaming support would require pinning the buffer across calls and could be a follow-up.

## Validation

`dotnet test -f net8.0`: 642 passed, 0 failed (4 pre-existing skips).

Found while building a delta-update tool on top of ZstdSharp.Port, where patches against a 168 MB base silently came out as full-size recompressions.